### PR TITLE
feat: using VERCEL_ENV instead of NODE_ENV

### DIFF
--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -318,9 +318,9 @@ const DEFAULT_OPTIONS = {
   cookieOptions: {
     path: '/',
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
+    secure: process.env.VERCEL_ENV === 'production',
     sameSite: 'Lax',
-    ...(env.NODE_ENV === 'production' && {
+    ...(process.env.VERCEL_ENV === 'production' && {
       domain: `.${env.NEXT_PUBLIC_WEB_URL}`,
     }),
   },


### PR DESCRIPTION
## Description

<!-- Please describe your changes in detail. -->

## Related Issue

<!-- Link to the issue this PR resolves (e.g., Closes #123) -->

Closes #

## Type of Change

<!-- Please check all options that apply: -->

- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Screenshots

<!-- If you made UI changes, please add before/after screenshots. Otherwise, you can remove this section. -->

## Checklist

- [ ] I have tested these changes
- [ ] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration to use Vercel-specific environment detection for cookie security settings, ensuring proper authentication behavior across deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->