### PR TITLE
fix: disable batch stream link for auth route

### DIFF
--- a/.changeset/fancy-emus-push.md
+++ b/.changeset/fancy-emus-push.md
@@ -1,0 +1,6 @@
+---
+'@yukinu/dashboard': patch
+'@yukinu/web': patch
+---
+
+disable batch stream link for auth route

--- a/apps/dashboard/src/trpc/react.tsx
+++ b/apps/dashboard/src/trpc/react.tsx
@@ -45,8 +45,7 @@ function TRPCReactProvider({
       links: [
         splitLink({
           condition: ({ path }) =>
-            env.NEXT_PUBLIC_TRPC_USE_STREAMING === 'true' &&
-            !path.startsWith('auth.'),
+            env.VITE_TRPC_USE_STREAMING === 'true' && !path.startsWith('auth.'),
           true: httpBatchStreamLink(configs),
           false: httpBatchLink(configs),
         }),

--- a/apps/dashboard/src/trpc/react.tsx
+++ b/apps/dashboard/src/trpc/react.tsx
@@ -44,7 +44,9 @@ function TRPCReactProvider({
     createTRPCClient<AppRouter>({
       links: [
         splitLink({
-          condition: () => env.VITE_TRPC_USE_STREAMING === 'true',
+          condition: ({ path }) =>
+            env.NEXT_PUBLIC_TRPC_USE_STREAMING === 'true' &&
+            !path.startsWith('auth.'),
           true: httpBatchStreamLink(configs),
           false: httpBatchLink(configs),
         }),

--- a/apps/web/trpc/react.tsx
+++ b/apps/web/trpc/react.tsx
@@ -46,7 +46,9 @@ function TRPCReactProvider({
     createTRPCClient<AppRouter>({
       links: [
         splitLink({
-          condition: () => env.NEXT_PUBLIC_TRPC_USE_STREAMING === 'true',
+          condition: ({ path }) =>
+            env.NEXT_PUBLIC_TRPC_USE_STREAMING === 'true' &&
+            !path.startsWith('auth.'),
           true: httpBatchStreamLink(configs),
           false: httpBatchLink(configs),
         }),


### PR DESCRIPTION
## Description

<!-- Please describe your changes in detail. -->
disable stream for auth routes because httpBatchStreamLink dont support set cookie

## Related Issue

<!-- Link to the issue this PR resolves (e.g., Closes #123) -->

Closes #

## Type of Change

<!-- Please check all options that apply: -->

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Screenshots

<!-- If you made UI changes, please add before/after screenshots. Otherwise, you can remove this section. -->

## Checklist

- [ ] I have tested these changes
- [ ] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled streaming for authentication routes so auth operations use the standard batch link for improved reliability.

* **Chores**
  * Added a changeset to publish patch updates for dashboard and web packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->